### PR TITLE
Added support for defining index

### DIFF
--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -31,4 +31,12 @@ else
  sed -i "s/http/$SPLUNK_PROTOCOL/g" /opt/app-root/src/fluentd.conf
 fi
 
+if [ -z $SPLUNK_INDEX ]
+then
+ echo "No SPLUNK_INDEX env variable set, using the default one in fluentd.conf."
+else
+ echo "SPLUNK_INDEX env variable set, replacing the default one in fluentd.conf."
+ sed -i "s/index main/index $SPLUNK_INDEX/g" /opt/app-root/src/fluentd.conf
+fi
+
 /opt/app-root/src/bundle/ruby/2.4.0/bin/fluentd -c /opt/app-root/src/fluentd.conf


### PR DESCRIPTION
There's an issue in Splunk 6.3, where HEC was new-ish, where defined index in client overrides the server setting at the HEC level. Adding this option to override the "index main" which was used in this project as default.