### PR TITLE
Support ConfigMap mounted fluentd.conf

### DIFF
--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -1,42 +1,54 @@
+#!/bin/bash
+
+FLUENT_CONF=/etc/config/fluentd.conf
+
+if [ ! -f $FLUENT_CONF ]
+then
+  echo "$FLUENT_CONF not mounted"
+  FLUENT_CONF=/opt/app-root/src/fluentd.conf
+  echo "Using built-in $FLUENT_CONF"
+fi
+
+export FLUENT_CONF
+
 if [ -z $SPLUNK_TOKEN ]
 then
-  echo "No SPLUNK_TOKEN env variable set, using the default one in fluentd.conf."
+  echo "No SPLUNK_TOKEN env variable set, using the default one in $FLUENT_CONF."
 else
-  echo "SPLUNK_TOKEN env variable set, replacing the default token in fluentd.conf."
-  sed -i "s/7084BC1F-DF53-42A7-AE43-2F6DDDD10E72/$SPLUNK_TOKEN/g" /opt/app-root/src/fluentd.conf
+  echo "SPLUNK_TOKEN env variable set, replacing the default token in $FLUENT_CONF."
+  sed -i "s/7084BC1F-DF53-42A7-AE43-2F6DDDD10E72/$SPLUNK_TOKEN/g" $FLUENT_CONF
 fi
 
 if [ -z $SPLUNK_SERVER ]
 then
- echo "No SPLUNK_SERVER env variable set, using the default one in fluentd.conf."
+ echo "No SPLUNK_SERVER env variable set, using the default one in $FLUENT_CONF."
 else
- echo "SPLUNK_SERVER env variable set, replacing the default token in fluentd.conf."
- sed -i "s/splunk.splunk.svc.cluster.local/$SPLUNK_SERVER/g" /opt/app-root/src/fluentd.conf
+ echo "SPLUNK_SERVER env variable set, replacing the default token in $FLUENT_CONF."
+ sed -i "s/splunk.splunk.svc.cluster.local/$SPLUNK_SERVER/g" $FLUENT_CONF
 fi
 
 if [ -z $SPLUNK_PORT ]
 then
- echo "No SPLUNK_PORT env variable set, using the default one in fluentd.conf."
+ echo "No SPLUNK_PORT env variable set, using the default one in $FLUENT_CONF."
 else
- echo "SPLUNK_PORT env variable set, replacing the default one in fluentd.conf."
- sed -i "s/8088/$SPLUNK_PORT/g" /opt/app-root/src/fluentd.conf
+ echo "SPLUNK_PORT env variable set, replacing the default one in $FLUENT_CONF."
+ sed -i "s/8088/$SPLUNK_PORT/g" $FLUENT_CONF
 fi
-
 
 if [ -z $SPLUNK_PROTOCOL ]
 then
- echo "No SPLUNK_PROTOCOL env variable set, using the default one in fluentd.conf."
+ echo "No SPLUNK_PROTOCOL env variable set, using the default one in $FLUENT_CONF."
 else
- echo "SPLUNK_PROTOCOL env variable set, replacing the default one in fluentd.conf."
- sed -i "s/http/$SPLUNK_PROTOCOL/g" /opt/app-root/src/fluentd.conf
+ echo "SPLUNK_PROTOCOL env variable set, replacing the default one in $FLUENT_CONF."
+ sed -i "s/http/$SPLUNK_PROTOCOL/g" $FLUENT_CONF
 fi
 
 if [ -z $SPLUNK_INDEX ]
 then
- echo "No SPLUNK_INDEX env variable set, using the default one in fluentd.conf."
+ echo "No SPLUNK_INDEX env variable set, using the default one in $FLUENT_CONF."
 else
- echo "SPLUNK_INDEX env variable set, replacing the default one in fluentd.conf."
- sed -i "s/index main/index $SPLUNK_INDEX/g" /opt/app-root/src/fluentd.conf
+ echo "SPLUNK_INDEX env variable set, replacing the default one in $FLUENT_CONF."
+ sed -i "s/index main/index $SPLUNK_INDEX/g" $FLUENT_CONF
 fi
 
-/opt/app-root/src/bundle/ruby/2.4.0/bin/fluentd -c /opt/app-root/src/fluentd.conf
+/opt/app-root/src/bundle/ruby/2.4.0/bin/fluentd

--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -51,4 +51,4 @@ else
  sed -i "s/index main/index $SPLUNK_INDEX/g" $FLUENT_CONF
 fi
 
-/opt/app-root/src/bundle/ruby/2.4.0/bin/fluentd
+/opt/app-root/src/bundle/ruby/2.4.0/bin/fluentd -c $FLUENT_CONF


### PR DESCRIPTION
Hi,

I added the ability to supply fluentd.conf as a ConfigMap mounted to /etc/config/. Makes it easier to play with the config as you don't have to build a new image for every change.

If it is not provided, fluentd will use the fluentd.conf on the image.